### PR TITLE
[GE] Impostor Fix.

### DIFF
--- a/KruacentE.GlobalEventFramework/GEFE.Examples/GE/Impostor.cs
+++ b/KruacentE.GlobalEventFramework/GEFE.Examples/GE/Impostor.cs
@@ -28,8 +28,7 @@ namespace GEFExiled.GEFE.Examples.GE
         private void ChangingPlayer()
         {
             // Liste des joueurs vivants
-            List<Player> serverPlayer = Player.List.Where(p => p.IsAlive).ToList();
-            List<Player> playerInServer = serverPlayer.Where(p => !p.IsNPC).ToList();
+            List<Player> playerInServer = Player.List.Where(p => !p.IsNPC && p.IsAlive).ToList();
 
             if (playerInServer.Count < 2)
             {
@@ -39,10 +38,8 @@ namespace GEFExiled.GEFE.Examples.GE
 
             // Debug : afficher la liste initiale des joueurs avec leurs rôles
             Log.Debug("===== Liste des joueurs avant permutation =====");
-            foreach (var player in playerInServer)
-            {
-                Log.Debug($"{player.Nickname} ({player.Role})");
-            }
+
+            playerInServer.ForEach(p => Log.Debug($"{p.Nickname} ({p.Role})"));
 
             // Mélanger la liste des joueurs
             playerInServer.ShuffleList();

--- a/KruacentE.GlobalEventFramework/GEFE.Examples/GE/Impostor.cs
+++ b/KruacentE.GlobalEventFramework/GEFE.Examples/GE/Impostor.cs
@@ -28,7 +28,8 @@ namespace GEFExiled.GEFE.Examples.GE
         private void ChangingPlayer()
         {
             // Liste des joueurs vivants
-            List<Player> playerInServer = Player.List.Where(p => p.IsAlive).ToList();
+            List<Player> serverPlayer = Player.List.Where(p => p.IsAlive).ToList();
+            List<Player> playerInServer = serverPlayer.Where(p => !p.IsNPC).ToList();
 
             if (playerInServer.Count < 2)
             {

--- a/KruacentE.GlobalEventFramework/GEFE.Examples/GE/Impostor.cs
+++ b/KruacentE.GlobalEventFramework/GEFE.Examples/GE/Impostor.cs
@@ -27,26 +27,46 @@ namespace GEFExiled.GEFE.Examples.GE
 
         private void ChangingPlayer()
         {
-            List<Player> playerInServer = Player.List.ToList();
+            // Liste des joueurs vivants
+            List<Player> playerInServer = Player.List.Where(p => p.IsAlive).ToList();
+
+            if (playerInServer.Count < 2)
+            {
+                Log.Warn("Pas assez de joueurs vivants pour effectuer un échange !");
+                return;
+            }
+
+            // Debug : afficher la liste initiale des joueurs avec leurs rôles
+            Log.Debug("===== Liste des joueurs avant permutation =====");
+            foreach (var player in playerInServer)
+            {
+                Log.Debug($"{player.Nickname} ({player.Role})");
+            }
+
+            // Mélanger la liste des joueurs
             playerInServer.ShuffleList();
 
-            //Affichage des joueurs pour le debug
-            playerInServer.ForEach(x => Log.Debug("Joueur : " + x.Nickname));
+            // Copier les données actuelles des joueurs
+            var originalNicknames = playerInServer.Select(p => p.Nickname).ToList();
+            var originalRoles = playerInServer.Select(p => p.Role).ToList();
 
-            foreach (Player player in playerInServer)
+            // Permutation circulaire des rôles et pseudonymes
+            for (int i = 0; i < playerInServer.Count; i++)
             {
-                Player otherPlayer = playerInServer.RandomItem();
+                int nextIndex = (i + 1) % playerInServer.Count;
+                playerInServer[i].ChangeAppearance(originalRoles[nextIndex]);
+                playerInServer[i].DisplayNickname = originalNicknames[nextIndex];
+            }
 
-
-                Log.Debug("Joueur Target : " + otherPlayer.Nickname);
-                Log.Debug("Role du Target : " + otherPlayer.Role);
-
-                player.ChangeAppearance(otherPlayer.Role);
-                player.DisplayNickname = otherPlayer.Nickname;
-
-                playerInServer.Remove(otherPlayer);
+            // Debug : afficher les correspondances après permutation
+            Log.Debug("===== Correspondances après permutation =====");
+            for (int i = 0; i < playerInServer.Count; i++)
+            {
+                int nextIndex = (i + 1) % playerInServer.Count;
+                Log.Debug($"{originalNicknames[i]} ({originalRoles[i]}) -> {originalNicknames[nextIndex]} ({originalRoles[nextIndex]})");
             }
         }
+
 
     }
 }

--- a/KruacentE.GlobalEventFramework/GEFE/Handlers/ServerHandler.cs
+++ b/KruacentE.GlobalEventFramework/GEFE/Handlers/ServerHandler.cs
@@ -23,20 +23,24 @@ namespace GEFExiled.Handlers
 		{
 			Log.Debug("starting round");
             _activeGE = _plugin.ChooseGE();
+            Log.Debug("sub event");
             _activeGE.ForEach(e => e.SubscribeEvent());
-			_plugin.Show();
+            Log.Debug("show to player");
+            _plugin.Show();
             Log.Debug("end starting round");
         }
 
-		public void OnEndingRound(EndingRoundEventArgs _)
+		public void OnEndingRound(RoundEndedEventArgs _)
 		{
             Log.Debug("ending round");
             _activeGE.ForEach(e => e.UnsubscribeEvent());
+            Timing.KillCoroutines();
         }
         public void OnRestartingRound()
         {
             Log.Debug("restarting");
             _activeGE.ForEach(e => e.UnsubscribeEvent());
+            Timing.KillCoroutines();    
         }
 
     }

--- a/KruacentE.GlobalEventFramework/MainPlugin.cs
+++ b/KruacentE.GlobalEventFramework/MainPlugin.cs
@@ -24,7 +24,7 @@ namespace GEFExiled
 		{
 
 			_instance = this;
-            List<IGlobalEvent> globalEvents = new List<IGlobalEvent>(){ new Shuffle(), new Speed(), new SystemMalfunction(), new RandomSpawn(), new R(), new Blitz(), new Impostor() };
+            List<IGlobalEvent> globalEvents = new List<IGlobalEvent>(){ new Shuffle(), new Speed(), new SystemMalfunction(), new RandomSpawn(), new R(), new Blitz() };
 			GlobalEvent.Register(globalEvents);
 
 			RegisterEvents();
@@ -45,7 +45,7 @@ namespace GEFExiled
 			_server = new Handlers.ServerHandler(this);
 
             ServerHandler.RoundStarted += _server.OnRoundStarted;
-            ServerHandler.EndingRound += _server.OnEndingRound;
+            ServerHandler.RoundEnded += _server.OnEndingRound;
 			ServerHandler.RestartingRound += _server.OnRestartingRound;
 
 		}
@@ -53,7 +53,7 @@ namespace GEFExiled
 		private void UnregisterEvents()
 		{
             ServerHandler.RoundStarted -= _server.OnRoundStarted;
-            ServerHandler.EndingRound -= _server.OnEndingRound;
+            ServerHandler.RoundEnded -= _server.OnEndingRound;
             ServerHandler.RestartingRound -= _server.OnRestartingRound;
 
             _server = null;


### PR DESCRIPTION
From now on, only players who are alive will be taken into account. Players who are dead and NPCs present in the game will be excluded.  

Every 3 to 5 minutes, the alive and non-NPC players will exchange their skins and pseudonyms.

## Process

Let’s take the example of a round consisting of the following players:

**NeoCox, Patrique, Delecons, Choco, and RotakZZ**

1. **Retrieve Alive and Non-NPC Players**  
   We filter out the dead players and NPCs, leaving us with only alive, non-NPC players.

2. **Shuffle the List of Players**  
   The original list `["NeoCox", "Patrique", "Delecons", "Choco", "RotakZZ"]` will be shuffled into a random order, for example:  
   `["Patrique", "RotakZZ", "Choco", "Delecons", "NeoCox"]`

3. **Circular Swap**  
   The players will exchange their skins and pseudonyms in a circular fashion:  
   - Patrique becomes RotakZZ  
   - RotakZZ becomes Choco  
   - Choco becomes Delecons  
   - Delecons becomes NeoCox  
   - NeoCox becomes Patrique  

4. **Repeat the Process**  
   Wait between 3 to 5 minutes, then repeat the same process.
